### PR TITLE
Add multi-service docker-compose stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
 # MoonBase
+
+This project provides a docker-compose stack with the following services:
+
+- **PostgreSQL** – database
+- **Keycloak** – authentication
+- **Elasticsearch** and **Kibana** – logging and search
+- **Prometheus** and **Grafana** – monitoring
+- **NGINX** – reverse proxy
+- **Status page** – simple web page displaying service status
+
+## Usage
+
+1. Ensure Docker and Docker Compose are installed.
+2. Run the stack:
+   ```bash
+   docker compose up -d
+   ```
+3. Visit `http://localhost` in your browser to see the status page.
+
+The status page will list each service and whether it is reachable (online/offline).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,84 @@
+version: '3.8'
+services:
+  postgres:
+    image: postgres:15
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: user
+      POSTGRES_PASSWORD: pass
+      POSTGRES_DB: appdb
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+
+  keycloak:
+    image: quay.io/keycloak/keycloak:23.0
+    restart: unless-stopped
+    command: start-dev
+    environment:
+      KC_DB: postgres
+      KC_DB_URL: jdbc:postgresql://postgres:5432/appdb
+      KC_DB_USERNAME: user
+      KC_DB_PASSWORD: pass
+      KEYCLOAK_ADMIN: admin
+      KEYCLOAK_ADMIN_PASSWORD: admin
+    depends_on:
+      - postgres
+
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.17.10
+    environment:
+      - discovery.type=single-node
+    volumes:
+      - esdata:/usr/share/elasticsearch/data
+    restart: unless-stopped
+
+  kibana:
+    image: docker.elastic.co/kibana/kibana:7.17.10
+    environment:
+      - ELASTICSEARCH_HOSTS=http://elasticsearch:9200
+    depends_on:
+      - elasticsearch
+    restart: unless-stopped
+
+  prometheus:
+    image: prom/prometheus:latest
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+    restart: unless-stopped
+
+  grafana:
+    image: grafana/grafana:latest
+    depends_on:
+      - prometheus
+    restart: unless-stopped
+
+  status:
+    build: ./status
+    ports:
+      - "3001:3001"
+    depends_on:
+      - postgres
+      - keycloak
+      - elasticsearch
+      - kibana
+      - prometheus
+      - grafana
+
+  nginx:
+    image: nginx:latest
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf:ro
+    ports:
+      - "80:80"
+    restart: unless-stopped
+    depends_on:
+      - status
+      - grafana
+      - kibana
+      - keycloak
+      - prometheus
+      - elasticsearch
+
+volumes:
+  pgdata:
+  esdata:

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,9 @@
+events {}
+http {
+    server {
+        listen 80;
+        location / {
+            proxy_pass http://status:3001/;
+        }
+    }
+}

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -1,0 +1,7 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ['prometheus:9090']

--- a/status/Dockerfile
+++ b/status/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:18-alpine
+WORKDIR /app
+COPY package.json ./
+RUN npm install --production
+COPY server.js ./
+EXPOSE 3001
+CMD ["npm", "start"]

--- a/status/package.json
+++ b/status/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "status-page",
+  "version": "1.0.0",
+  "description": "Service status page",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}

--- a/status/server.js
+++ b/status/server.js
@@ -1,0 +1,73 @@
+const express = require('express');
+const net = require('net');
+
+function checkPort(host, port) {
+  return new Promise((resolve) => {
+    const socket = new net.Socket();
+    socket.setTimeout(2000);
+    socket.on('connect', () => {
+      socket.destroy();
+      resolve(true);
+    }).on('error', () => {
+      resolve(false);
+    }).on('timeout', () => {
+      resolve(false);
+    }).connect(port, host);
+  });
+}
+
+async function checkHttp(url) {
+  try {
+    const res = await fetch(url);
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+const checks = [
+  { name: 'PostgreSQL', type: 'tcp', host: 'postgres', port: 5432 },
+  { name: 'Keycloak', type: 'http', url: 'http://keycloak:8080' },
+  { name: 'Elasticsearch', type: 'http', url: 'http://elasticsearch:9200' },
+  { name: 'Kibana', type: 'http', url: 'http://kibana:5601' },
+  { name: 'Prometheus', type: 'http', url: 'http://prometheus:9090/-/ready' },
+  { name: 'Grafana', type: 'http', url: 'http://grafana:3000' },
+  { name: 'NGINX', type: 'http', url: 'http://nginx' },
+];
+
+async function getStatuses() {
+  return Promise.all(
+    checks.map(async (c) => {
+      let online = false;
+      if (c.type === 'tcp') {
+        online = await checkPort(c.host, c.port);
+      } else {
+        online = await checkHttp(c.url);
+      }
+      return { name: c.name, online };
+    })
+  );
+}
+
+const app = express();
+app.get('/', async (_req, res) => {
+  const statuses = await getStatuses();
+  res.send(`<!doctype html>
+<html>
+<head><title>Service Status</title></head>
+<body>
+<h1>Service Status</h1>
+<table border="1" cellspacing="0" cellpadding="4">
+<tr><th>Service</th><th>Status</th></tr>
+${statuses
+  .map((s) => `<tr><td>${s.name}</td><td>${s.online ? 'online' : 'offline'}</td></tr>`) 
+  .join('\n')}
+</table>
+</body>
+</html>`);
+});
+
+const port = 3001;
+app.listen(port, () => {
+  console.log('Status page listening on port', port);
+});


### PR DESCRIPTION
## Summary
- configure docker-compose stack with PostgreSQL, Keycloak, Elasticsearch, Kibana, Prometheus, Grafana, NGINX and a status page
- implement status page service in Node.js
- add basic NGINX and Prometheus configs
- document stack usage in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842dc0fdf088326a6239c76a840192b