### PR TITLE
Update status links and add Keycloak routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ This project provides a docker-compose stack with the following services:
    ```bash
    docker compose up -d
    ```
-3. Visit `http://localhost` in your browser to see the status page.
-
-The status page will list each service and whether it is reachable (online/offline).
+3. Open `http://localhost` in your browser. You will be redirected to the
+   Keycloak login page. After authentication you can reach the simple
+   confirmation page at `/online` which displays `TU ES ONLINE`.
+4. The service status table is available at `http://localhost/status/` and lists
+   each service with a link to its interface.

--- a/nginx.conf
+++ b/nginx.conf
@@ -4,8 +4,20 @@ http {
     server {
         listen 80;
 
-        # Route vers l'application "status"
+        # Redirige vers Keycloak par défaut
         location / {
+            return 302 /keycloak/;
+        }
+
+        # Page de confirmation
+        location /online {
+            proxy_pass http://status:3001/online;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+        }
+
+        # Statut des services
+        location /status/ {
             proxy_pass http://status:3001/;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
@@ -21,6 +33,20 @@ http {
         # Kibana
         location /kibana/ {
             proxy_pass http://kibana:5601/;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+        }
+
+        # Prometheus
+        location /prometheus/ {
+            proxy_pass http://prometheus:9090/;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+        }
+
+        # Grafana
+        location /grafana/ {
+            proxy_pass http://grafana:3000/;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
         }

--- a/status/server.js
+++ b/status/server.js
@@ -26,13 +26,49 @@ async function checkHttp(url) {
 }
 
 const checks = [
-  { name: 'PostgreSQL', type: 'tcp', host: 'postgres', port: 5432 },
-  { name: 'Keycloak', type: 'http', url: 'http://keycloak:8080' },
-  { name: 'Elasticsearch', type: 'http', url: 'http://elasticsearch:9200' },
-  { name: 'Kibana', type: 'http', url: 'http://kibana:5601' },
-  { name: 'Prometheus', type: 'http', url: 'http://prometheus:9090/-/ready' },
-  { name: 'Grafana', type: 'http', url: 'http://grafana:3000' },
-  { name: 'NGINX', type: 'http', url: 'http://nginx' },
+  {
+    name: 'PostgreSQL',
+    type: 'tcp',
+    host: 'postgres',
+    port: 5432,
+    ui: null,
+  },
+  {
+    name: 'Keycloak',
+    type: 'http',
+    url: 'http://keycloak:8080',
+    ui: '/keycloak/',
+  },
+  {
+    name: 'Elasticsearch',
+    type: 'http',
+    url: 'http://elasticsearch:9200',
+    ui: '/elasticsearch/',
+  },
+  {
+    name: 'Kibana',
+    type: 'http',
+    url: 'http://kibana:5601',
+    ui: '/kibana/',
+  },
+  {
+    name: 'Prometheus',
+    type: 'http',
+    url: 'http://prometheus:9090/-/ready',
+    ui: '/prometheus/',
+  },
+  {
+    name: 'Grafana',
+    type: 'http',
+    url: 'http://grafana:3000',
+    ui: '/grafana/',
+  },
+  {
+    name: 'NGINX',
+    type: 'http',
+    url: 'http://nginx',
+    ui: '/',
+  },
 ];
 
 async function getStatuses() {
@@ -44,7 +80,7 @@ async function getStatuses() {
       } else {
         online = await checkHttp(c.url);
       }
-      return { name: c.name, online };
+      return { name: c.name, online, ui: c.ui };
     })
   );
 }
@@ -58,13 +94,17 @@ app.get('/', async (_req, res) => {
 <body>
 <h1>Service Status</h1>
 <table border="1" cellspacing="0" cellpadding="4">
-<tr><th>Service</th><th>Status</th></tr>
+<tr><th>Service</th><th>Status</th><th>URL</th></tr>
 ${statuses
-  .map((s) => `<tr><td>${s.name}</td><td>${s.online ? 'online' : 'offline'}</td></tr>`) 
+  .map((s) => `<tr><td>${s.name}</td><td>${s.online ? 'online' : 'offline'}</td><td>${s.ui ? `<a href="${s.ui}">${s.ui}</a>` : ''}</td></tr>`)
   .join('\n')}
 </table>
 </body>
 </html>`);
+});
+
+app.get('/online', (_req, res) => {
+  res.send('<h1>TU ES ONLINE</h1>');
 });
 
 const port = 3001;


### PR DESCRIPTION
## Summary
- add interface links to all services
- add `TU ES ONLINE` page
- route through Keycloak by default in nginx
- update README usage section

## Testing
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6842e22ee9f4832692507b17a82447ca