### PR TITLE
Improve NGINX routing for Elasticsearch alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,4 +20,5 @@ This project provides a docker-compose stack with the following services:
    Keycloak login page. After authentication you can reach the simple
    confirmation page at `/online` which displays `TU ES ONLINE`.
 4. The service status table is available at `http://localhost/status/` and lists
-   each service with a link to its interface.
+   each service with a link to its interface. `Elasticsearch` can now also be
+   reached via `/elastic/` in addition to `/elasticsearch/`.

--- a/nginx.conf
+++ b/nginx.conf
@@ -54,10 +54,22 @@ http {
         }
 
         # Elasticsearch (optionnel)
+        # Permet d'accéder via /elasticsearch/ ou /elastic/
         location /elasticsearch/ {
             proxy_pass http://elasticsearch:9200/;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
+        }
+
+        location /elastic/ {
+            proxy_pass http://elasticsearch:9200/;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+        }
+
+        # Redirige /elastic vers /elastic/ pour plus de souplesse
+        location = /elastic {
+            return 302 /elastic/;
         }
     }
 }


### PR DESCRIPTION
## Summary
- allow `/elastic/` URL alongside `/elasticsearch/`
- document new alias in README

## Testing
- `docker compose config` *(fails: `docker: command not found`)*
- `node -e "require('vm').runInThisContext(require('fs').readFileSync('status/server.js','utf8'))"` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_6842e806bbb88326966bc883fea2683f