### PR TITLE
Update nginx configuration

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -4,6 +4,11 @@ http {
     server {
         listen 80;
 
+        # Allow cross origin requests for all proxied services
+        add_header 'Access-Control-Allow-Origin' '*';
+        add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, OPTIONS';
+        add_header 'Access-Control-Allow-Headers' '*';
+
         # Redirige vers Keycloak par défaut
         location / {
             proxy_pass http://keycloak:8080/;
@@ -25,11 +30,20 @@ http {
             proxy_set_header X-Real-IP $remote_addr;
         }
 
+        # Allow access without trailing slash
+        location = /status {
+            return 302 /status/;
+        }
+
         # Keycloak
         location /keycloak/ {
             proxy_pass http://keycloak:8080/;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
+        }
+
+        location = /keycloak {
+            return 302 /keycloak/;
         }
 
         # Kibana
@@ -39,11 +53,19 @@ http {
             proxy_set_header X-Real-IP $remote_addr;
         }
 
+        location = /kibana {
+            return 302 /kibana/;
+        }
+
         # Prometheus
         location /prometheus/ {
             proxy_pass http://prometheus:9090/;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
+        }
+
+        location = /prometheus {
+            return 302 /prometheus/;
         }
 
         # Grafana
@@ -53,12 +75,20 @@ http {
             proxy_set_header X-Real-IP $remote_addr;
         }
 
+        location = /grafana {
+            return 302 /grafana/;
+        }
+
         # Elasticsearch (optionnel)
         # Permet d'accéder via /elasticsearch/ ou /elastic/
         location /elasticsearch/ {
             proxy_pass http://elasticsearch:9200/;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
+        }
+
+        location = /elasticsearch {
+            return 302 /elasticsearch/;
         }
 
         location /elastic/ {


### PR DESCRIPTION
## Summary
- allow CORS for all proxied services
- add redirects without trailing slash for status, keycloak, kibana, prometheus, grafana and elasticsearch

## Testing
- `docker compose config` *(fails: docker not installed)*
- `npm start` *(fails: cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_6842e93fe6348326a92fe34b28e94c6e