### PR TITLE
Fix Grafana path redirection

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,6 +51,9 @@ services:
     depends_on:
       - prometheus
     restart: unless-stopped
+    environment:
+      GF_SERVER_ROOT_URL: "http://localhost/grafana/"
+      GF_SERVER_SERVE_FROM_SUB_PATH: "true"
 
   status:
     build: ./status


### PR DESCRIPTION
## Summary
- configure Grafana to work from `/grafana` reverse-proxy path

## Testing
- `n/a`

------
https://chatgpt.com/codex/tasks/task_e_68448d701478832692982ed358c9d86d