### PR TITLE
Fix Grafana path handling

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,6 +51,9 @@ services:
     depends_on:
       - prometheus
     restart: unless-stopped
+    environment:
+      GF_SERVER_ROOT_URL: "http://localhost/grafana"
+      GF_SERVER_SERVE_FROM_SUB_PATH: "true"
 
   status:
     build: ./status

--- a/nginx.conf
+++ b/nginx.conf
@@ -70,7 +70,7 @@ http {
 
         # Grafana
         location /grafana/ {
-            proxy_pass http://grafana:3000/;
+            proxy_pass http://grafana:3000;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
         }


### PR DESCRIPTION
## Summary
- set Grafana root URL without trailing slash
- keep `/grafana/` prefix when proxying requests

## Testing
- `n/a`

------
https://chatgpt.com/codex/tasks/task_e_68448d701478832692982ed358c9d86d