### PR TITLE
Fix Grafana path handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,5 @@ This project provides a docker-compose stack with the following services:
 4. The service status table is available at `http://localhost/status/` and lists
    each service with a link to its interface. `Elasticsearch` can now also be
    reached via `/elastic/` in addition to `/elasticsearch/`.
+   Grafana, Prometheus and Kibana are served from `/grafana/`, `/prometheus/`
+   and `/kibana/` respectively after logging into Keycloak.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,12 +36,17 @@ services:
     image: docker.elastic.co/kibana/kibana:7.17.10
     environment:
       - ELASTICSEARCH_HOSTS=http://elasticsearch:9200
+      - SERVER_BASEPATH=/kibana
+      - SERVER_REWRITEBASEPATH=true
     depends_on:
       - elasticsearch
     restart: unless-stopped
 
   prometheus:
     image: prom/prometheus:latest
+    command:
+      - '--web.route-prefix=/prometheus'
+      - '--web.external-url=http://localhost/prometheus'
     volumes:
       - ./prometheus.yml:/etc/prometheus/prometheus.yml
     restart: unless-stopped
@@ -51,6 +56,9 @@ services:
     depends_on:
       - prometheus
     restart: unless-stopped
+    environment:
+      GF_SERVER_ROOT_URL: "http://localhost/grafana"
+      GF_SERVER_SERVE_FROM_SUB_PATH: "true"
 
   status:
     build: ./status

--- a/nginx.conf
+++ b/nginx.conf
@@ -48,7 +48,7 @@ http {
 
         # Kibana
         location /kibana/ {
-            proxy_pass http://kibana:5601/;
+            proxy_pass http://kibana:5601;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
         }
@@ -59,7 +59,7 @@ http {
 
         # Prometheus
         location /prometheus/ {
-            proxy_pass http://prometheus:9090/;
+            proxy_pass http://prometheus:9090;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
         }
@@ -70,7 +70,7 @@ http {
 
         # Grafana
         location /grafana/ {
-            proxy_pass http://grafana:3000/;
+            proxy_pass http://grafana:3000;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
         }


### PR DESCRIPTION
## Summary
- set Grafana root URL without trailing slash
- keep `/grafana/` prefix when proxying requests
- configure Prometheus and Kibana for subpaths

## Testing
- `n/a`

------
https://chatgpt.com/codex/tasks/task_e_68448d701478832692982ed358c9d86d