### PR TITLE
Add Keycloak realm configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This project provides a docker-compose stack with the following services:
 
 - **PostgreSQL** – database
-- **Keycloak** – authentication
+- **Keycloak** – authentication (importing `keycloak/keycloak-realm.json` on startup)
 - **Elasticsearch** and **Kibana** – logging and search
 - **Prometheus** and **Grafana** – monitoring
 - **NGINX** – reverse proxy
@@ -20,6 +20,9 @@ This project provides a docker-compose stack with the following services:
    ```bash
    docker compose up -d
    ```
+   Keycloak will automatically import the realm definition from
+   `./keycloak/keycloak-realm.json`, which registers the `frontend` and
+   `backend` clients.
 3. Open `http://localhost` in your browser. You will be redirected to the
    Keycloak login page. After authentication you can reach the simple
    confirmation page at `/online` which displays `TU ES ONLINE`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,9 @@ services:
   keycloak:
     image: quay.io/keycloak/keycloak:23.0
     restart: unless-stopped
-    command: start-dev
+    command: start-dev --import-realm
+    volumes:
+      - ./keycloak:/opt/keycloak/data/import
     environment:
       KC_DB: postgres
       KC_DB_URL: jdbc:postgresql://postgres:5432/system_database

--- a/frontend/pages/_app.js
+++ b/frontend/pages/_app.js
@@ -6,8 +6,8 @@ export default function App({ Component, pageProps }) {
   useEffect(() => {
     const keycloak = new Keycloak({
       url: '/keycloak/',
-      realm: 'master',
-      clientId: 'account',
+      realm: 'moonbase',
+      clientId: 'frontend',
     });
     keycloak.init({ onLoad: 'login-required' }).then((authenticated) => {
       if (authenticated && keycloak.tokenParsed) {

--- a/keycloak/keycloak-realm.json
+++ b/keycloak/keycloak-realm.json
@@ -1,0 +1,21 @@
+{
+  "realm": "moonbase",
+  "enabled": true,
+  "clients": [
+    {
+      "clientId": "frontend",
+      "publicClient": true,
+      "redirectUris": [
+        "http://localhost/app/*"
+      ],
+      "webOrigins": [
+        "http://localhost"
+      ],
+      "rootUrl": "http://localhost/app/"
+    },
+    {
+      "clientId": "backend",
+      "bearerOnly": true
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add `keycloak` folder containing a realm configuration JSON
- import the realm on Keycloak startup via docker-compose
- update Keycloak usage instructions in README
- update frontend to use the new `moonbase` realm and `frontend` client

## Testing
- `gofmt -w main.go`
- `go vet ./...` *(fails: forbidden to download modules)*
- `npm run build` in `frontend` *(fails: `next` not found)*
- `npm install` & `npm test` in `status` *(fails: 403 forbidden / missing test script)*

------
https://chatgpt.com/codex/tasks/task_e_6846d9b44a0483269d102b7f87461217