### PR TITLE
Reset Keycloak schema on each start

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 This project provides a docker-compose stack with the following services:
 
 - **PostgreSQL** – database
-- **Keycloak** – authentication (importing `keycloak/keycloak-realm.json` on startup)
+- **Keycloak** – authentication. The database schema is reset on each start and
+  the realm from `keycloak/keycloak-realm.json` is re-imported automatically.
 - **Elasticsearch** and **Kibana** – logging and search
 - **Prometheus** and **Grafana** – monitoring
 - **NGINX** – reverse proxy
@@ -20,7 +21,7 @@ This project provides a docker-compose stack with the following services:
    ```bash
    docker compose up -d
    ```
-   Keycloak will automatically import the realm definition from
+   Keycloak will reset its schema and then import the realm definition from
    `./keycloak/keycloak-realm.json`, which registers the `frontend` and
    `backend` clients.
 3. Open `http://localhost` in your browser. You will be redirected to the

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,14 +24,16 @@ services:
   keycloak:
     image: quay.io/keycloak/keycloak:23.0
     restart: unless-stopped
-    command: start-dev --import-realm
+    command: /opt/keycloak/init.sh
     volumes:
       - ./keycloak:/opt/keycloak/data/import
+      - ./keycloak/init.sh:/opt/keycloak/init.sh:ro
     environment:
       KC_DB: postgres
       KC_DB_URL: jdbc:postgresql://postgres:5432/system_database
       KC_DB_USERNAME: user
       KC_DB_PASSWORD: pass
+      KC_DB_SCHEMA: keycloak
       KEYCLOAK_ADMIN: admin
       KEYCLOAK_ADMIN_PASSWORD: admin
     depends_on:

--- a/keycloak/init.sh
+++ b/keycloak/init.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -e
+
+# Wait for PostgreSQL to be available
+until PGPASSWORD="$KC_DB_PASSWORD" psql "$KC_DB_URL" -U "$KC_DB_USERNAME" -c '\q' >/dev/null 2>&1; do
+  echo "Waiting for PostgreSQL..."
+  sleep 1
+done
+
+SCHEMA="${KC_DB_SCHEMA:-public}"
+
+# Drop and recreate the Keycloak schema
+PGPASSWORD="$KC_DB_PASSWORD" psql "$KC_DB_URL" -U "$KC_DB_USERNAME" <<SQL
+DROP SCHEMA IF EXISTS "$SCHEMA" CASCADE;
+CREATE SCHEMA "$SCHEMA";
+SQL
+
+exec /opt/keycloak/bin/kc.sh start-dev --import-realm


### PR DESCRIPTION
## Summary
- add Keycloak init script that drops the schema and imports the realm
- mount this script in docker-compose and set `KC_DB_SCHEMA`
- document new behaviour in README

## Testing
- `go vet ./...` *(fails: Forbidden)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6846ddc2de3883268213fea093b9d683