### PR TITLE
Use dedicated schemas for Keycloak and application

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,20 @@
 
 This project provides a docker-compose stack with the following services:
 
-- **PostgreSQL** – database
-- **Keycloak** – authentication. The database schema is reset on each start and
-  the realm from `keycloak/keycloak-realm.json` is re-imported automatically.
+- **PostgreSQL** – database with two schemas: `keycloak` for Keycloak and
+  `app` for the application tables.
+- **Keycloak** – authentication. The `keycloak` schema is reset on each start
+  and the realm from `keycloak/keycloak-realm.json` is re-imported
+  automatically.
 - **Elasticsearch** and **Kibana** – logging and search
 - **Prometheus** and **Grafana** – monitoring
 - **NGINX** – reverse proxy
 - **Status page** – simple web page displaying service status
 - **Backend** – Go service powered by Echo
 - **Frontend** – React/Next.js UI styled with Tailwind CSS
-- The PostgreSQL instance initializes a database named `system_database`
-  containing a single table called `users`.
+- The PostgreSQL instance initializes a database named `system_database`.
+  Application tables live under the `app` schema and Keycloak stores its data
+  in the `keycloak` schema.
 
 ## Usage
 

--- a/db-init/V1__init.sql
+++ b/db-init/V1__init.sql
@@ -1,15 +1,9 @@
--- V1__init.sql
+CREATE SCHEMA IF NOT EXISTS app;
 
-CREATE TABLE IF NOT EXISTS user_account (
+CREATE TABLE IF NOT EXISTS app.users (
     id SERIAL PRIMARY KEY,
     username VARCHAR(255) NOT NULL UNIQUE,
     email VARCHAR(255),
     nbre_de_connexions INTEGER DEFAULT 0,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-);
-
-CREATE TABLE IF NOT EXISTS migration_model (
-    id SERIAL PRIMARY KEY,
-    version VARCHAR(50) NOT NULL,
-    update_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -92,7 +92,7 @@ services:
   backend:
     build: ./backend
     environment:
-      DATABASE_URL: postgres://user:pass@postgres:5432/system_database?sslmode=disable
+      DATABASE_URL: postgres://user:pass@postgres:5432/system_database?sslmode=disable&search_path=app
     depends_on:
       - postgres
 

--- a/keycloak/init.sh
+++ b/keycloak/init.sh
@@ -15,4 +15,4 @@ DROP SCHEMA IF EXISTS "$SCHEMA" CASCADE;
 CREATE SCHEMA "$SCHEMA";
 SQL
 
-exec /opt/keycloak/bin/kc.sh start-dev --import-realm
+exec /opt/keycloak/bin/kc.sh start-dev --db-schema="$SCHEMA" --import-realm


### PR DESCRIPTION
## Summary
- configure backend to use `app` schema
- place app tables in the new `app` schema
- pass `--db-schema` to Keycloak startup script
- document new schema setup in README

## Testing
- `go build ./...` *(fails: Forbidden)*
- `npm install --omit=dev` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6846e4b756388326934ec1d5866ad5d8