### PR TITLE
Add custom Keycloak image with init script

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ This project provides a docker-compose stack with the following services:
 ## Usage
 
 1. Ensure Docker and Docker Compose are installed.
-2. Run the stack:
+2. Run the stack. Docker Compose will build a small Keycloak image using
+   `keycloak/Dockerfile` so that our `init.sh` script runs before Keycloak
+   starts:
    ```bash
    docker compose up -d
    ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,12 +22,10 @@ services:
       - ./db-init:/flyway/sql
 
   keycloak:
-    image: quay.io/keycloak/keycloak:23.0
+    build: ./keycloak
     restart: unless-stopped
-    command: /opt/keycloak/init.sh
     volumes:
-      - ./keycloak:/opt/keycloak/data/import
-      - ./keycloak/init.sh:/opt/keycloak/init.sh:ro
+      - ./keycloak/keycloak-realm.json:/opt/keycloak/data/import/keycloak-realm.json:ro
     environment:
       KC_DB: postgres
       KC_DB_URL: jdbc:postgresql://postgres:5432/system_database

--- a/keycloak/Dockerfile
+++ b/keycloak/Dockerfile
@@ -1,0 +1,5 @@
+FROM quay.io/keycloak/keycloak:23.0
+COPY init.sh /opt/keycloak/init.sh
+COPY keycloak-realm.json /opt/keycloak/data/import/keycloak-realm.json
+RUN chmod +x /opt/keycloak/init.sh
+ENTRYPOINT ["/opt/keycloak/init.sh"]


### PR DESCRIPTION
## Summary
- add a Dockerfile in the `keycloak` folder so that `init.sh` runs as the container entrypoint
- update docker-compose to build the new image and mount only the realm file
- document the new build step in README

## Testing
- `docker compose config` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6846e7420284832685ae2153a3787d9a