### PR TITLE
Implement light-themed UI layout

### DIFF
--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -1,9 +1,11 @@
 import { useState } from 'react';
 
+// Menus used to demonstrate a simple light themed application layout
 const themes = {
-  Dashboard: ['Overview', 'Stats', 'Graphs'],
-  Settings: ['Profile', 'Preferences', 'Security'],
-  Reports: ['Monthly', 'Annual', 'Custom'],
+  Accueil: ['Tableau de bord', 'Rapports'],
+  'Mon Profil': ['Informations', 'Préférences'],
+  Paramètres: ['Général', 'Sécurité'],
+  Configuration: ['Système', 'Intégrations'],
 };
 
 export default function Home() {
@@ -14,14 +16,15 @@ export default function Home() {
   const actions = themes[selectedTheme];
 
   return (
-    <div className="flex h-screen text-gray-200 bg-gray-900">
-      {/* Global menu */}
-      <div className="w-48 bg-gray-800 p-4 space-y-2">
+    <div className="flex flex-col h-screen text-gray-800 bg-gray-100">
+      <div className="flex flex-1">
+        {/* Global menu */}
+        <div className="w-48 bg-white p-4 space-y-2 border-r">
         {themeKeys.map((t) => (
           <button
             key={t}
             className={`block w-full text-left px-2 py-1 rounded ${
-              selectedTheme === t ? 'bg-gray-700' : 'hover:bg-gray-700'
+              selectedTheme === t ? 'bg-blue-200' : 'hover:bg-blue-100'
             }`}
             onClick={() => {
               setSelectedTheme(t);
@@ -34,12 +37,12 @@ export default function Home() {
       </div>
 
       {/* Actions for selected theme */}
-      <div className="w-48 bg-gray-800 p-4 space-y-2 border-l border-gray-700">
+      <div className="w-48 bg-gray-50 p-4 space-y-2 border-l">
         {actions.map((a) => (
           <button
             key={a}
             className={`block w-full text-left px-2 py-1 rounded ${
-              selectedAction === a ? 'bg-gray-700' : 'hover:bg-gray-700'
+              selectedAction === a ? 'bg-blue-200' : 'hover:bg-blue-100'
             }`}
             onClick={() => setSelectedAction(a)}
           >
@@ -49,12 +52,20 @@ export default function Home() {
       </div>
 
       {/* Main content */}
-      <div className="flex-1 p-8" style={{ width: '70%' }}>
-        <h1 className="text-2xl font-semibold mb-4">{selectedTheme} - {selectedAction}</h1>
-        <div className="bg-gray-800 rounded p-4">
-          <p>Content for {selectedAction} in {selectedTheme}.</p>
+        <div className="flex-1 p-8" style={{ width: '70%' }}>
+          <h1 className="text-2xl font-semibold mb-4">{selectedTheme} - {selectedAction}</h1>
+          <div className="bg-white rounded p-4 shadow">
+            <p>Content for {selectedAction} in {selectedTheme}.</p>
+          </div>
         </div>
       </div>
+      <footer className="h-10 bg-gray-200 border-t flex items-center justify-between px-4 text-sm">
+        <div>Users: 102 • Memory: 68%</div>
+        <div className="space-x-2">
+          <a href="#" className="text-blue-600 hover:underline">Docs</a>
+          <a href="#" className="text-blue-600 hover:underline">Support</a>
+        </div>
+      </footer>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- switch example page to a light theme
- add standard menus like **Mon Profil**, **Paramètres** and **Configuration**
- show a small footer with metrics and quick links

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846ef0f58e88326b2b98492b777c04f