### PR TITLE
Improve Keycloak startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,11 @@ This project provides a docker-compose stack with the following services:
 ## Usage
 
 1. Ensure Docker and Docker Compose are installed.
-2. Run the stack:
+2. Run the stack. Docker Compose will build a small Keycloak image using
+   `keycloak/Dockerfile`. The container launches our `init.sh` script first
+   which now resolves database parameters from `KC_DB_URL` and calls Keycloak
+   via a relative path, so the setup works regardless of the installation
+   location:
    ```bash
    docker compose up -d
    ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,15 +22,13 @@ services:
       - ./db-init:/flyway/sql
 
   keycloak:
-    image: quay.io/keycloak/keycloak:23.0
+    build: ./keycloak
     restart: unless-stopped
-    command: /opt/keycloak/init.sh
     volumes:
-      - ./keycloak:/opt/keycloak/data/import
-      - ./keycloak/init.sh:/opt/keycloak/init.sh:ro
+      - ./keycloak/keycloak-realm.json:/opt/keycloak/data/import/keycloak-realm.json:ro
     environment:
       KC_DB: postgres
-      KC_DB_URL: jdbc:postgresql://postgres:5432/system_database
+      KC_DB_URL: jdbc:postgresql://postgres:5432/system_database?currentSchema=keycloak
       KC_DB_USERNAME: user
       KC_DB_PASSWORD: pass
       KC_DB_SCHEMA: keycloak

--- a/keycloak/Dockerfile
+++ b/keycloak/Dockerfile
@@ -1,0 +1,12 @@
+FROM quay.io/keycloak/keycloak:23.0
+WORKDIR /opt/keycloak
+
+# Copy the initialization script and realm file using paths
+# relative to the Keycloak home directory so that the image
+# works regardless of the absolute installation prefix.
+COPY init.sh ./init.sh
+COPY keycloak-realm.json ./data/import/keycloak-realm.json
+
+# Ensure the init script is executable and use it as the entrypoint.
+RUN chmod +x init.sh
+ENTRYPOINT ["./init.sh"]

--- a/keycloak/init.sh
+++ b/keycloak/init.sh
@@ -1,8 +1,20 @@
-#!/bin/bash
+#!/bin/sh
 set -e
 
-# Wait for PostgreSQL to be available
-until PGPASSWORD="$KC_DB_PASSWORD" psql "$KC_DB_URL" -U "$KC_DB_USERNAME" -c '\q' >/dev/null 2>&1; do
+# Wait for PostgreSQL to be available. The JDBC connection string is
+# converted to parameters that `psql` understands so we don't depend on
+# absolute paths or a particular URL format.
+URL_NO_PREFIX="${KC_DB_URL#jdbc:postgresql://}"
+HOST_PORT="${URL_NO_PREFIX%%/*}"
+DB_NAME="${URL_NO_PREFIX#*/}"
+DB_NAME="${DB_NAME%%\?*}"
+DB_HOST="${HOST_PORT%%:*}"
+DB_PORT="${HOST_PORT##*:}"
+[ "$DB_PORT" = "$HOST_PORT" ] && DB_PORT=5432
+
+PSQL_CMD="psql -h $DB_HOST -p $DB_PORT -U $KC_DB_USERNAME $DB_NAME"
+
+until PGPASSWORD="$KC_DB_PASSWORD" $PSQL_CMD -c '\q' >/dev/null 2>&1; do
   echo "Waiting for PostgreSQL..."
   sleep 1
 done
@@ -10,9 +22,11 @@ done
 SCHEMA="${KC_DB_SCHEMA:-public}"
 
 # Drop and recreate the Keycloak schema
-PGPASSWORD="$KC_DB_PASSWORD" psql "$KC_DB_URL" -U "$KC_DB_USERNAME" <<SQL
+PGPASSWORD="$KC_DB_PASSWORD" $PSQL_CMD <<SQL
 DROP SCHEMA IF EXISTS "$SCHEMA" CASCADE;
 CREATE SCHEMA "$SCHEMA";
 SQL
 
-exec /opt/keycloak/bin/kc.sh start-dev --db-schema="$SCHEMA" --import-realm
+# Start Keycloak using a relative path so the script works regardless of the
+# absolute installation location.
+exec ./bin/kc.sh start-dev --db-schema="$SCHEMA" --import-realm


### PR DESCRIPTION
## Summary
- run Keycloak init script from working directory
- extract DB connection parameters in `init.sh`
- start Keycloak via relative path
- set currentSchema in compose file
- document the more robust setup

## Testing
- `docker compose config` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6846e7420284832685ae2153a3787d9a