### PR TITLE
Enable Elasticsearch security features

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,6 +49,7 @@ services:
       discovery.type: single-node
     volumes:
       - esdata:/usr/share/elasticsearch/data
+      - ./elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml:ro
     restart: unless-stopped
 
   kibana:

--- a/elasticsearch.yml
+++ b/elasticsearch.yml
@@ -1,0 +1,3 @@
+xpack.security.enabled: true
+xpack.security.authc.api_key.enabled: true
+


### PR DESCRIPTION
## Summary
- add new `elasticsearch.yml` config enabling security and API keys
- mount the config in docker-compose so Elasticsearch picks it up

## Testing
- `npm test --prefix frontend` *(fails: Missing script)*
- `npm test --prefix status` *(fails: Missing script)*
- `go test ./...` in `backend` *(fails: could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68484dbe56fc8326a1df7096e0032995