### PR TITLE
Add Keycloak tenant realm setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@ This project provides a docker-compose stack with the following services:
 - **PostgreSQL** – database with two schemas: `keycloak` for Keycloak and
   `app` for the application tables.
 - **Keycloak** – authentication. The `keycloak` schema is reset on each start
-  and the realm from `keycloak/keycloak-realm.json` is re-imported
-  automatically.
+  and the realms from `keycloak/keycloak-realm.json`, `keycloak/realm-t1.json`
+  and `keycloak/realm-t2.json` are re-imported automatically. The additional
+  realm files create tenants **T1** and **T2** with a single user each.
 - **Elasticsearch** and **Kibana** – logging and search
 - **Prometheus** and **Grafana** – monitoring
 - **NGINX** – reverse proxy
@@ -29,12 +30,15 @@ This project provides a docker-compose stack with the following services:
    ```bash
    docker compose up -d
    ```
-   Keycloak will reset its schema and then import the realm definition from
-   `./keycloak/keycloak-realm.json`, which registers the `frontend` and
-   `backend` clients.
+ Keycloak will reset its schema and then import the realm definitions from
+  `./keycloak/keycloak-realm.json`, `./keycloak/realm-t1.json` and
+  `./keycloak/realm-t2.json`. These files register the `frontend` and `backend`
+  clients and create one user in each tenant.
 3. Open `http://localhost` in your browser. You will be redirected to the
    Keycloak login page. After authentication you can reach the simple
    confirmation page at `/online` which displays `TU ES ONLINE`.
+   The example user credentials are `T1`/`password` for realm **T1** and
+   `T2`/`password` for realm **T2**.
 4. The service status table is available at `http://localhost/status/` and lists
    each service with a link to its interface. `Elasticsearch` can now also be
    reached via `/elastic/` in addition to `/elasticsearch/`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,8 @@ services:
       KEYCLOAK_ADMIN_PASSWORD: admin
     volumes:
       - ./keycloak/keycloak-realm.json:/opt/keycloak/data/import/keycloak-realm.json:ro
+      - ./keycloak/realm-t1.json:/opt/keycloak/data/import/realm-t1.json:ro
+      - ./keycloak/realm-t2.json:/opt/keycloak/data/import/realm-t2.json:ro
     depends_on:
       - postgres
       - flyway

--- a/keycloak/realm-t1.json
+++ b/keycloak/realm-t1.json
@@ -1,0 +1,34 @@
+{
+  "realm": "T1",
+  "enabled": true,
+  "users": [
+    {
+      "username": "T1",
+      "enabled": true,
+      "credentials": [
+        {
+          "type": "password",
+          "value": "password",
+          "temporary": false
+        }
+      ]
+    }
+  ],
+  "clients": [
+    {
+      "clientId": "frontend",
+      "publicClient": true,
+      "redirectUris": [
+        "http://localhost/app/*"
+      ],
+      "webOrigins": [
+        "http://localhost"
+      ],
+      "rootUrl": "http://localhost/app/"
+    },
+    {
+      "clientId": "backend",
+      "bearerOnly": true
+    }
+  ]
+}

--- a/keycloak/realm-t2.json
+++ b/keycloak/realm-t2.json
@@ -1,0 +1,34 @@
+{
+  "realm": "T2",
+  "enabled": true,
+  "users": [
+    {
+      "username": "T2",
+      "enabled": true,
+      "credentials": [
+        {
+          "type": "password",
+          "value": "password",
+          "temporary": false
+        }
+      ]
+    }
+  ],
+  "clients": [
+    {
+      "clientId": "frontend",
+      "publicClient": true,
+      "redirectUris": [
+        "http://localhost/app/*"
+      ],
+      "webOrigins": [
+        "http://localhost"
+      ],
+      "rootUrl": "http://localhost/app/"
+    },
+    {
+      "clientId": "backend",
+      "bearerOnly": true
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- import multiple realms on startup
- add realm configs for T1 and T2 with one user each
- document tenants and credentials

## Testing
- `go vet ./...` *(fails: forbidden to download modules)*
- `go test ./...` *(fails: forbidden to download modules)*
- `npm install` *(fails: 403 Forbidden from registry)*
- `npm run build` *(fails: Next.js not found due to failed install)*

------
https://chatgpt.com/codex/tasks/task_e_68496d62670c8326a1cfc76791912e43