### PR TITLE
Improve Elastic and Kibana setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,6 +49,7 @@ services:
     image: docker.elastic.co/elasticsearch/elasticsearch:7.17.10
     environment:
       discovery.type: single-node
+      ELASTIC_PASSWORD: ${ELASTIC_PASSWORD:-changeme}
     volumes:
       - esdata:/usr/share/elasticsearch/data
       - ./elasticsearch/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml:ro
@@ -59,6 +60,8 @@ services:
     environment:
       SERVER_BASEPATH: /kibana
       SERVER_REWRITEBASEPATH: "true"
+      ELASTICSEARCH_USERNAME: ${ELASTIC_USERNAME:-elastic}
+      ELASTICSEARCH_PASSWORD: ${ELASTIC_PASSWORD:-changeme}
     volumes:
       - ./kibana/kibana.yml:/usr/share/kibana/config/kibana.yml:ro
     depends_on:

--- a/elasticsearch/elasticsearch.yml
+++ b/elasticsearch/elasticsearch.yml
@@ -1,3 +1,10 @@
 xpack.security.enabled: true
 xpack.security.authc.api_key.enabled: true
 
+# Cluster configuration
+cluster.name: moonbase
+node.name: single-node
+
+# Bind to all network interfaces for container access
+network.host: 0.0.0.0
+

--- a/kibana/kibana.yml
+++ b/kibana/kibana.yml
@@ -1,3 +1,7 @@
 server.host: "0.0.0.0"
 server.port: 5601
 elasticsearch.hosts: ["http://elasticsearch:9200"]
+
+# Credentials to connect to secured Elasticsearch
+elasticsearch.username: "${ELASTIC_USERNAME:-elastic}"
+elasticsearch.password: "${ELASTIC_PASSWORD:-changeme}"


### PR DESCRIPTION
## Summary
- expose Elasticsearch on all interfaces and set basic cluster info
- allow Kibana to authenticate to Elasticsearch
- make credentials configurable via environment variables

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6849785f8b208326b67af37d612aef65