### PR TITLE
Add instructions for connecting Kibana to App Search

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,4 +45,29 @@ This project provides a docker-compose stack with the following services:
    Grafana, Prometheus and Kibana are served from `/grafana/`, `/prometheus/`
    and `/kibana/` respectively after logging into Keycloak.
 5. The application UI is served from `/app/` and the API endpoint returning
-   "Welcome to the home page" is available at `/api/home`.
+ "Welcome to the home page" is available at `/api/home`.
+
+## Indexing a website with App Search
+
+This stack can also connect to an Elastic App Search instance for web
+indexing. Assuming an App Search service is available at
+`http://localhost:3002`, configure Kibana and restart it:
+
+```yaml
+enterpriseSearch.host: 'http://localhost:3002'
+```
+
+Then restart the Kibana container:
+
+```bash
+docker compose restart kibana
+```
+
+Within Kibana navigate to **App Search** and create an engine. From there you
+can use the **Web Crawler** to index [`https://www.intalio.com`](https://www.intalio.com).
+
+### Troubleshooting
+
+- App Search and Kibana must point to the same Elasticsearch cluster.
+- Both services need the same authentication method.
+- Kibana's App Search UI does not support the Standard authentication mode.

--- a/kibana/kibana.yml
+++ b/kibana/kibana.yml
@@ -5,3 +5,6 @@ elasticsearch.hosts: ["http://elasticsearch:9200"]
 # Credentials to connect to secured Elasticsearch
 elasticsearch.username: "${ELASTIC_USERNAME:-elastic}"
 elasticsearch.password: "${ELASTIC_PASSWORD:-changeme}"
+
+# Connect Kibana to an App Search instance
+enterpriseSearch.host: "http://localhost:3002"


### PR DESCRIPTION
## Summary
- document how to hook Kibana up to an App Search instance
- show example config and troubleshooting notes
- include enterpriseSearch.host in the sample kibana.yml

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68499293d0f4832685c57fac1fa26aca