### PR TITLE
Add Elastic Agent for Keycloak logs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,6 +68,20 @@ services:
       - elasticsearch
     restart: unless-stopped
 
+  elastic-agent:
+    image: docker.elastic.co/beats/elastic-agent:7.17.10
+    user: root
+    volumes:
+      - ./elastic-agent/elastic-agent.yml:/usr/share/elastic-agent/elastic-agent.yml:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - /var/lib/docker/containers:/var/lib/docker/containers:ro
+    environment:
+      ELASTIC_USERNAME: ${ELASTIC_USERNAME:-elastic}
+      ELASTIC_PASSWORD: ${ELASTIC_PASSWORD:-changeme}
+    depends_on:
+      - elasticsearch
+    restart: unless-stopped
+
   prometheus:
     image: prom/prometheus:latest
     command:

--- a/elastic-agent/elastic-agent.yml
+++ b/elastic-agent/elastic-agent.yml
@@ -1,0 +1,20 @@
+outputs:
+  default:
+    type: elasticsearch
+    hosts: ["http://elasticsearch:9200"]
+    username: ${ELASTIC_USERNAME:-elastic}
+    password: ${ELASTIC_PASSWORD:-changeme}
+inputs:
+  - type: filestream
+    id: keycloak-logs
+    paths:
+      - /var/lib/docker/containers/*/*.log
+    parsers:
+      - docker: {}
+    processors:
+      - add_docker_metadata: ~
+      - drop_event:
+          when:
+            not:
+              regexp:
+                container.name: ".*keycloak.*"


### PR DESCRIPTION
## Summary
- deploy elastic-agent container to stream Keycloak logs into Elasticsearch
- configure log collection for the Keycloak container

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68499814d3108326b72d5337047f22a0