### PR TITLE
Configure Grafana database schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,21 +2,22 @@
 
 This project provides a docker-compose stack with the following services:
 
-- **PostgreSQL** – database with two schemas: `keycloak` for Keycloak and
-  `app` for the application tables.
+- **PostgreSQL** – database with schemas: `keycloak` for Keycloak, `app` for the
+  application tables and `grafana` for Grafana's own data.
 - **Keycloak** – authentication. The `keycloak` schema is reset on each start
   and the realms from `keycloak/keycloak-realm.json`, `keycloak/realm-t1.json`
   and `keycloak/realm-t2.json` are re-imported automatically. The additional
   realm files create tenants **T1** and **T2** with a single user each.
 - **Elasticsearch** and **Kibana** – logging and search
-- **Prometheus** and **Grafana** – monitoring
+- **Prometheus** and **Grafana** – monitoring. Grafana stores its dashboards in
+  the `grafana` schema.
 - **NGINX** – reverse proxy
 - **Status page** – simple web page displaying service status
 - **Backend** – Go service powered by Echo
 - **Frontend** – React/Next.js UI styled with Tailwind CSS
 - The PostgreSQL instance initializes a database named `system_database`.
-  Application tables live under the `app` schema and Keycloak stores its data
-  in the `keycloak` schema.
+  Application tables live under the `app` schema, Keycloak stores its data in
+  the `keycloak` schema and Grafana uses the `grafana` schema.
 
 ## Usage
 

--- a/db-init/V4__create_grafana_schema.sql
+++ b/db-init/V4__create_grafana_schema.sql
@@ -1,0 +1,35 @@
+-- V4__create_grafana_schema.sql
+
+-- Cleanup existing Grafana schema
+DO
+$$
+DECLARE
+    r RECORD;
+BEGIN
+    -- Drop views
+    FOR r IN (SELECT table_name FROM information_schema.views WHERE table_schema = 'grafana') LOOP
+        EXECUTE 'DROP VIEW IF EXISTS grafana.' || quote_ident(r.table_name) || ' CASCADE';
+    END LOOP;
+
+    -- Drop tables
+    FOR r IN (SELECT table_name FROM information_schema.tables WHERE table_schema = 'grafana') LOOP
+        EXECUTE 'DROP TABLE IF EXISTS grafana.' || quote_ident(r.table_name) || ' CASCADE';
+    END LOOP;
+
+    -- Drop sequences
+    FOR r IN (SELECT sequence_name FROM information_schema.sequences WHERE sequence_schema = 'grafana') LOOP
+        EXECUTE 'DROP SEQUENCE IF EXISTS grafana.' || quote_ident(r.sequence_name) || ' CASCADE';
+    END LOOP;
+
+    -- Drop functions
+    FOR r IN (SELECT routine_name FROM information_schema.routines WHERE routine_schema = 'grafana') LOOP
+        EXECUTE 'DROP FUNCTION IF EXISTS grafana.' || quote_ident(r.routine_name) || ' CASCADE';
+    END LOOP;
+END
+$$;
+
+-- Create the Grafana schema
+CREATE SCHEMA IF NOT EXISTS grafana;
+
+-- Permissions for Grafana
+GRANT USAGE ON SCHEMA grafana TO "user";

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       -user=user
       -password=pass
       -connectRetries=10
-      -schemas=public,keycloak,app
+      -schemas=public,keycloak,app,grafana
       migrate
     volumes:
       - ./db-init:/flyway/sql
@@ -115,10 +115,18 @@ services:
     image: grafana/grafana:latest
     depends_on:
       - prometheus
+      - postgres
     restart: unless-stopped
     environment:
       GF_SERVER_ROOT_URL: "http://localhost/grafana"
       GF_SERVER_SERVE_FROM_SUB_PATH: "true"
+      GF_DATABASE_TYPE: "postgres"
+      GF_DATABASE_HOST: "postgres:5432"
+      GF_DATABASE_NAME: ${POSTGRES_DB:-system_database}
+      GF_DATABASE_USER: ${POSTGRES_USER:-user}
+      GF_DATABASE_PASSWORD: ${POSTGRES_PASSWORD:-pass}
+      GF_DATABASE_SSL_MODE: "disable"
+      GF_DATABASE_SCHEMA: "grafana"
 
   status:
     build: ./status


### PR DESCRIPTION
## Summary
- set Grafana to use PostgreSQL and the `grafana` schema
- create Flyway migration that creates the `grafana` schema
- document new schema in README

## Testing
- `go vet ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684ac23cf0788326b1810ce547b84f9d