### PR TITLE
Add OpenSearch realm client and dashboard path

### DIFF
--- a/keycloak/keycloak-realm.json
+++ b/keycloak/keycloak-realm.json
@@ -16,6 +16,14 @@
     {
       "clientId": "backend",
       "bearerOnly": true
+    },
+    {
+      "clientId": "opensearch",
+      "secret": "opensearch-secret",
+      "publicClient": false,
+      "redirectUris": [
+        "http://localhost/dashboards/auth/openid/login"
+      ]
     }
   ]
 }

--- a/nginx.conf
+++ b/nginx.conf
@@ -60,14 +60,14 @@ http {
         }
 
         # OpenSearch Dashboards
-        location /opensearch-dashboards/ {
+        location /dashboards/ {
             proxy_pass http://opensearch-dashboards:5601;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
         }
 
-        location = /opensearch-dashboards {
-            return 302 /opensearch-dashboards/;
+        location = /dashboards {
+            return 302 /dashboards/;
         }
 
         # Prometheus


### PR DESCRIPTION
## Summary
- add `opensearch` confidential client in Keycloak realm definition
- expose OpenSearch Dashboards under `/dashboards` via nginx

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684c32432fcc83268a68e9cf3c905de0