### PR TITLE
Make docker-compose configurable via env file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,17 @@
+# Example environment configuration for MoonBase
+# Secret file locations
+POSTGRES_USER_FILE=./secrets/postgres_user.txt
+POSTGRES_PASSWORD_FILE=./secrets/postgres_password.txt
+KEYCLOAK_ADMIN_FILE=./secrets/keycloak_admin.txt
+KEYCLOAK_PASSWORD_FILE=./secrets/keycloak_password.txt
+GRAFANA_PASSWORD_FILE=./secrets/grafana_password.txt
+
+# Database configuration
+POSTGRES_DB=system_database
+POSTGRES_PORT=5432
+
+# Exposed service ports
+STATUS_PORT=3001
+NGINX_PORT=80
+OPENSEARCH_PORT=9200
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,12 +7,12 @@ services:
     environment:
       POSTGRES_USER_FILE: /run/secrets/postgres_user
       POSTGRES_PASSWORD_FILE: /run/secrets/postgres_password
-      POSTGRES_DB: system_database
+      POSTGRES_DB: ${POSTGRES_DB:-system_database}
     secrets:
       - postgres_user
       - postgres_password
     ports:
-      - "5432:5432"
+      - "${POSTGRES_PORT:-5432}:5432"
     volumes:
       - pgdata:/var/lib/postgresql/data
 
@@ -21,7 +21,7 @@ services:
     depends_on:
       - postgres
     command: >
-      -url=jdbc:postgresql://postgres:5432/system_database
+      -url=jdbc:postgresql://postgres:${POSTGRES_PORT:-5432}/${POSTGRES_DB:-system_database}
       -user=$(cat /run/secrets/postgres_user)
       -password=$(cat /run/secrets/postgres_password)
       -connectRetries=10
@@ -38,7 +38,7 @@ services:
     restart: unless-stopped
     environment:
       KC_DB: postgres
-      KC_DB_URL: jdbc:postgresql://postgres:5432/system_database?currentSchema=keycloak
+      KC_DB_URL: jdbc:postgresql://postgres:${POSTGRES_PORT:-5432}/${POSTGRES_DB:-system_database}?currentSchema=keycloak
       KC_DB_USERNAME_FILE: /run/secrets/postgres_user
       KC_DB_PASSWORD_FILE: /run/secrets/postgres_password
       KC_DB_SCHEMA: keycloak
@@ -75,7 +75,7 @@ services:
     environment:
       SERVER_BASEPATH: /dashboards
       SERVER_REWRITEBASEPATH: "true"
-      OPENSEARCH_HOSTS: '["http://opensearch:9200"]'
+      OPENSEARCH_HOSTS: '["http://opensearch:${OPENSEARCH_PORT:-9200}"]'
     volumes:
       - ./opensearch-dashboards/opensearch_dashboards.yml:/usr/share/opensearch-dashboards/config/opensearch_dashboards.yml:ro
     depends_on:
@@ -102,8 +102,8 @@ services:
       GF_SERVER_ROOT_URL: "http://localhost/grafana"
       GF_SERVER_SERVE_FROM_SUB_PATH: "true"
       GF_DATABASE_TYPE: "postgres"
-      GF_DATABASE_HOST: "postgres:5432"
-      GF_DATABASE_NAME: system_database
+      GF_DATABASE_HOST: "postgres:${POSTGRES_PORT:-5432}"
+      GF_DATABASE_NAME: ${POSTGRES_DB:-system_database}
       GF_DATABASE_USER_FILE: /run/secrets/postgres_user
       GF_DATABASE_PASSWORD_FILE: /run/secrets/postgres_password
       GF_DATABASE_SSL_MODE: "disable"
@@ -119,7 +119,7 @@ services:
   status:
     build: ./status
     ports:
-      - "3001:3001"
+      - "${STATUS_PORT:-3001}:3001"
     depends_on:
       - postgres
       - keycloak
@@ -131,7 +131,7 @@ services:
   backend:
     build: ./backend
     environment:
-      DATABASE_URL: postgres://user:pass@postgres:5432/system_database?sslmode=disable&search_path=app
+      DATABASE_URL: postgres://user:pass@postgres:${POSTGRES_PORT:-5432}/${POSTGRES_DB:-system_database}?sslmode=disable&search_path=app
     depends_on:
       - postgres
 
@@ -145,7 +145,7 @@ services:
     volumes:
       - ./nginx.conf:/etc/nginx/nginx.conf:ro
     ports:
-      - "80:80"
+      - "${NGINX_PORT:-80}:80"
     restart: unless-stopped
     depends_on:
       - status
@@ -162,12 +162,12 @@ volumes:
 
 secrets:
   postgres_user:
-    file: ./secrets/postgres_user.txt
+    file: ${POSTGRES_USER_FILE:-./secrets/postgres_user.txt}
   postgres_password:
-    file: ./secrets/postgres_password.txt
+    file: ${POSTGRES_PASSWORD_FILE:-./secrets/postgres_password.txt}
   keycloak_admin:
-    file: ./secrets/keycloak_admin.txt
+    file: ${KEYCLOAK_ADMIN_FILE:-./secrets/keycloak_admin.txt}
   keycloak_password:
-    file: ./secrets/keycloak_password.txt
+    file: ${KEYCLOAK_PASSWORD_FILE:-./secrets/keycloak_password.txt}
   grafana_password:
-    file: ./secrets/grafana_password.txt
+    file: ${GRAFANA_PASSWORD_FILE:-./secrets/grafana_password.txt}


### PR DESCRIPTION
## Summary
- add `.env.example` with sample environment settings
- allow overriding service ports and database parameters via environment variables
- reference secret file locations using variables

## Testing
- `docker compose config` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684ca749ef1083268896e3311b0d09b6