### PR TITLE
Add additional web modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ This project provides a docker-compose stack with the following services:
 - **Status page** – simple web page displaying service status
 - **Backend** – Go service powered by Echo
 - **Frontend** – React/Next.js UI styled with Tailwind CSS
+- **FileGator** – web file manager served from `/filegator/`
+- **Outline** – knowledge base accessible at `/outline/`
+- **Answer** – community Q&A at `/answer/`
+- **Typesense** – search engine used by Outline and Answer, API available at `/typesense/`
+- **Metabase** – analytics UI served from `/metabase/`
+- **Redis** – cache for Outline
 - The PostgreSQL instance initializes a database named `system_database`.
   Application tables live under the `app` schema, Keycloak stores its data in
   the `keycloak` schema and Grafana uses the `grafana` schema.
@@ -46,6 +52,23 @@ This project provides a docker-compose stack with the following services:
    and `/dashboards/` respectively after logging into Keycloak.
 5. The application UI is served from `/app/` and the API endpoint returning
 "Welcome to the home page" is available at `/api/home`.
+
+Additional modules are available once you clone the optional submodules:
+
+```bash
+git submodule update --init
+```
+
+They are served from the following paths after starting the stack:
+
+- FileGator: `http://localhost/filegator/`
+- Outline: `http://localhost/outline/`
+- Answer: `http://localhost/answer/`
+- Typesense API: `http://localhost/typesense/`
+- Metabase: `http://localhost/metabase/`
+
+Outline and Answer automatically connect to Typesense using the shared
+`TYPESENSE_API_KEY` environment variable defined in `docker-compose.yml`.
 
 ## Integrating OpenSearch with Keycloak
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,11 @@ services:
       - "${POSTGRES_PORT:-5432}:5432"
     volumes:
       - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "postgres"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
   flyway:
     image: flyway/flyway:latest
@@ -56,6 +61,11 @@ services:
     depends_on:
       - postgres
       - flyway
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health/ready"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
 
   opensearch:
     image: opensearchproject/opensearch:latest
@@ -69,6 +79,11 @@ services:
       - osdata:/usr/share/opensearch/data
       - ./opensearch/opensearch.yml:/usr/share/opensearch/config/opensearch.yml:ro
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9200"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
 
   opensearch-dashboards:
     image: opensearchproject/opensearch-dashboards:latest
@@ -81,6 +96,11 @@ services:
     depends_on:
       - opensearch
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:5601/api/status"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
 
   prometheus:
     image: prom/prometheus:latest
@@ -91,6 +111,11 @@ services:
     volumes:
       - ./prometheus.yml:/etc/prometheus/prometheus.yml
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:9090/-/ready"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
 
   grafana:
     image: grafana/grafana:latest
@@ -115,6 +140,11 @@ services:
       - grafana_password
     volumes:
       - grafana-storage:/var/lib/grafana
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3000/api/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
 
   status:
     build: ./status
@@ -127,6 +157,11 @@ services:
       - opensearch-dashboards
       - prometheus
       - grafana
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3001/online"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
 
   backend:
     build: ./backend
@@ -134,11 +169,115 @@ services:
       DATABASE_URL: postgres://user:pass@postgres:${POSTGRES_PORT:-5432}/${POSTGRES_DB:-system_database}?sslmode=disable&search_path=app
     depends_on:
       - postgres
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/api/home"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
 
   frontend:
     build: ./frontend
     depends_on:
       - keycloak
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3000"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+
+  typesense:
+    image: typesense/typesense:latest
+    command: ["--data-dir", "/data", "--api-key", "${TYPESENSE_API_KEY:-secret}"]
+    volumes:
+      - typesense-data:/data
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8108/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+
+  filegator:
+    image: filegator/filegator:latest
+    depends_on:
+      - typesense
+    volumes:
+      - filegator-data:/var/www/filegator/repository
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+
+  redis:
+    image: redis:7
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+
+  outline:
+    image: outlinewiki/outline:latest
+    environment:
+      DATABASE_URL: postgres://user:pass@postgres:${POSTGRES_PORT:-5432}/${POSTGRES_DB:-system_database}
+      DATABASE_SSL: "false"
+      REDIS_URL: redis://redis:6379
+      SECRET_KEY: "changeme"
+      UTILS_SECRET: "changeme"
+      URL: http://localhost/outline
+      TYPESENSE_API_KEY: ${TYPESENSE_API_KEY:-secret}
+      TYPESENSE_NODES: '[{"host":"typesense","port":8108,"protocol":"http"}]'
+    depends_on:
+      - postgres
+      - redis
+      - typesense
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3000"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+
+  answer:
+    image: answerdev/answer:latest
+    environment:
+      DB_TYPE: postgresql
+      DB_DSN: postgres://user:pass@postgres:${POSTGRES_PORT:-5432}/${POSTGRES_DB:-system_database}?sslmode=disable
+      TYPESENSE_ENDPOINT: http://typesense:8108
+      TYPESENSE_API_KEY: ${TYPESENSE_API_KEY:-secret}
+    depends_on:
+      - postgres
+      - typesense
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+
+  metabase:
+    image: metabase/metabase:latest
+    depends_on:
+      - postgres
+    restart: unless-stopped
+    environment:
+      MB_DB_TYPE: postgres
+      MB_DB_DBNAME: ${POSTGRES_DB:-system_database}
+      MB_DB_PORT: ${POSTGRES_PORT:-5432}
+      MB_DB_USER_FILE: /run/secrets/postgres_user
+      MB_DB_PASS_FILE: /run/secrets/postgres_password
+      MB_DB_HOST: postgres
+    secrets:
+      - postgres_user
+      - postgres_password
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3000/api/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
 
   nginx:
     image: nginx:stable-alpine
@@ -154,11 +293,23 @@ services:
       - keycloak
       - prometheus
       - opensearch
+      - filegator
+      - outline
+      - answer
+      - metabase
+      - typesense
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
 
 volumes:
   pgdata:
   osdata:
   grafana-storage:
+  typesense-data:
+  filegator-data:
 
 secrets:
   postgres_user:

--- a/nginx.conf
+++ b/nginx.conf
@@ -123,5 +123,55 @@ http {
         location = /elastic {
             return 302 /elastic/;
         }
+
+        location /filegator/ {
+            proxy_pass http://filegator/;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+        }
+
+        location = /filegator {
+            return 302 /filegator/;
+        }
+
+        location /outline/ {
+            proxy_pass http://outline:3000/;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+        }
+
+        location = /outline {
+            return 302 /outline/;
+        }
+
+        location /answer/ {
+            proxy_pass http://answer/;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+        }
+
+        location = /answer {
+            return 302 /answer/;
+        }
+
+        location /typesense/ {
+            proxy_pass http://typesense:8108/;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+        }
+
+        location = /typesense {
+            return 302 /typesense/;
+        }
+
+        location /metabase/ {
+            proxy_pass http://metabase:3000/;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+        }
+
+        location = /metabase {
+            return 302 /metabase/;
+        }
     }
 }

--- a/status/server.js
+++ b/status/server.js
@@ -80,6 +80,36 @@ const checks = [
     ui: '/app/',
   },
   {
+    name: 'Typesense',
+    type: 'http',
+    url: 'http://typesense:8108/health',
+    ui: '/typesense/',
+  },
+  {
+    name: 'FileGator',
+    type: 'http',
+    url: 'http://filegator',
+    ui: '/filegator/',
+  },
+  {
+    name: 'Outline',
+    type: 'http',
+    url: 'http://outline:3000',
+    ui: '/outline/',
+  },
+  {
+    name: 'Answer',
+    type: 'http',
+    url: 'http://answer',
+    ui: '/answer/',
+  },
+  {
+    name: 'Metabase',
+    type: 'http',
+    url: 'http://metabase:3000/api/health',
+    ui: '/metabase/',
+  },
+  {
     name: 'NGINX',
     type: 'http',
     url: 'http://nginx',


### PR DESCRIPTION
## Summary
- add services for Typesense, FileGator, Outline, Answer and Metabase
- configure reverse proxy for new services
- connect Outline and Answer with Typesense
- include healthchecks for all services
- show new modules on status page
- document integration and submodule setup

## Testing
- `docker compose config` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684ca99778c483268d2a2c0818fb3a06